### PR TITLE
Fix to boot.poll method

### DIFF
--- a/src/boot.js
+++ b/src/boot.js
@@ -561,15 +561,18 @@
         pollDelay = pollDelay || 1;
 
         timers[name] = setInterval(function () {
-
+            var result = check();
             time = now() - start;
 
             if (timeout && time > timeout) {
                 isTimeout = true;
             }
 
-            if (check() || isTimeout) {
+            if (result) {
                 callback.call(window, isTimeout, time);
+            }
+
+            if (result || isTimeout){
                 clearInterval(timers[name]);
             }
 

--- a/src/boot.js
+++ b/src/boot.js
@@ -28,6 +28,7 @@
 
         // Localize global objects and functions for better compression.
         document = window.document,
+        version = "0.3",
         JSON = window.JSON,
         setTimeout = window.setTimeout,
 
@@ -126,6 +127,12 @@
 
     global.log = log;
 
+/*
+    Function: Boot.version
+
+    The current version of boot being used
+*/
+    global.version = version;
 
 /*
     Function: Boot.contains


### PR DESCRIPTION
Boot.poll timeout was firing the callback when the timeout was used, regardless of if the check was true or not.
